### PR TITLE
Fix sector deletion in sector mode

### DIFF
--- a/src/MapEditor/Edit/Edit2D.cpp
+++ b/src/MapEditor/Edit/Edit2D.cpp
@@ -1136,8 +1136,6 @@ void Edit2D::deleteSector() const
 		for (unsigned s = 0; s < sector->connectedSides().size(); s++)
 			connected_sides.push_back(sector->connectedSides()[s]);
 		sector->getLines(connected_lines);
-
-		context_.map().removeSector(sector);
 	}
 
 	// Remove all connected sides


### PR DESCRIPTION
Since removeSide now removes sectors, deleting a sector will result in two sectors being deleted. This change delegates the sector deletion to removeSide.

NOTE: If you intend to merge SLADE's master or stable branch, I've already made a pull request like this to SLADE, and it has already been merged.